### PR TITLE
0130実装

### DIFF
--- a/lib/ui/git_repository_info_view.dart
+++ b/lib/ui/git_repository_info_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -157,38 +158,39 @@ class ContributorsView extends HookConsumerWidget {
     final ghTokenProvider = ref.read(githubTokenProvider);
     final ghOrganizationProvider = ref.read(githubOrganizationProvider);
 
-    return FutureBuilder(
-        future: getContributor(
-            repositoryName, ghTokenProvider, ghOrganizationProvider),
-        builder: (context, snapshot) {
-          if (snapshot.hasData && snapshot.data != null) {
-            return Wrap(
-              spacing: 5,
-              children: snapshot.data!
-                  .map((e) => GestureDetector(
-                        onTap: () => Navigator.of(context).push(
-                          MaterialPageRoute(
-                            builder: (context) =>
-                                UserInfoView(userId: e.nodeId),
-                          ),
-                        ),
-                        child: SizedBox(
-                          width: 40.0,
-                          height: 40.0,
-                          child: Container(
-                            decoration: BoxDecoration(
-                                shape: BoxShape.circle,
-                                image: DecorationImage(
-                                    fit: BoxFit.fill,
-                                    image:
-                                        NetworkImage(e.avatarUri.toString()))),
-                          ),
-                        ),
-                      ))
-                  .toList(),
-            );
-          }
-          return const LoadingAnimation();
-        });
+    useMemoized(() => getContributor(
+        repositoryName, ghTokenProvider, ghOrganizationProvider));
+    final contributorsData = useFuture(useMemoized(() => getContributor(
+        repositoryName, ghTokenProvider, ghOrganizationProvider)));
+    if (!contributorsData.hasData) {
+      return const LoadingAnimation();
+    }
+
+    if (contributorsData.data != null) {
+      return Wrap(
+        spacing: 5,
+        children: contributorsData.data!
+            .map((e) => GestureDetector(
+                  onTap: () => Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (context) => UserInfoView(userId: e.nodeId),
+                    ),
+                  ),
+                  child: SizedBox(
+                    width: 40.0,
+                    height: 40.0,
+                    child: Container(
+                      decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          image: DecorationImage(
+                              fit: BoxFit.fill,
+                              image: NetworkImage(e.avatarUri.toString()))),
+                    ),
+                  ),
+                ))
+            .toList(),
+      );
+    }
+    return const LoadingAnimation();
   }
 }

--- a/lib/ui/git_repository_info_view.dart
+++ b/lib/ui/git_repository_info_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:repositoryviewer/restapi/get_contributer.dart';
+import 'package:repositoryviewer/ui/exception_message_view.dart';
 import 'package:repositoryviewer/ui/user_info_view.dart';
 
 import '../graphql/get_repository_info_from_id.graphql.dart';
@@ -164,6 +165,8 @@ class ContributorsView extends HookConsumerWidget {
         repositoryName, ghTokenProvider, ghOrganizationProvider)));
     if (!contributorsData.hasData) {
       return const LoadingAnimation();
+    } else if (contributorsData.hasError) {
+      return ExceptionMessageView(message: contributorsData.error!.toString());
     }
 
     if (contributorsData.data != null) {
@@ -191,6 +194,6 @@ class ContributorsView extends HookConsumerWidget {
             .toList(),
       );
     }
-    return const LoadingAnimation();
+    return const ExceptionMessageView(message: "Value is null");
   }
 }

--- a/lib/ui/settings_view.dart
+++ b/lib/ui/settings_view.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:graphql/client.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:repositoryviewer/provider/github_account_setting_provider.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:repositoryviewer/provider/bookmarked_git_repository_provider.dart';
+import 'package:repositoryviewer/provider/github_account_setting_provider.dart';
 import 'package:repositoryviewer/ui/user_info_view.dart';
 
 import '../graphql/get_organization_list.graphql.dart';
@@ -51,7 +53,13 @@ class SettingsView extends HookConsumerWidget {
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                 ),
-                onTap: () {}),
+                onTap: () async {
+                  PackageInfo.fromPlatform().then((value) => showLicensePage(
+                      context: context,
+                      applicationName: value.appName,
+                      applicationVersion: value.version,
+                      applicationIcon: const FlutterLogo()));
+                }),
             ListTile(
                 title: Text(
                   'github token',
@@ -121,6 +129,12 @@ class TokenInputDialog extends HookConsumerWidget {
       title: const Text('Tokenを入力して下さい'),
       content: TextField(
         decoration: const InputDecoration(hintText: 'ここに入力'),
+        keyboardType: TextInputType.visiblePassword,
+        //半角英数字のみ入力可能
+        inputFormatters: [
+          FilteringTextInputFormatter.allow(
+              RegExp(r'^[ -~]*$')),
+        ],
         onChanged: (value) {
           valueText = value;
         },
@@ -148,7 +162,8 @@ class OrganizationSelectDialog extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final ghOrganizationNotifier = ref.read(githubOrganizationProvider.notifier);
+    final ghOrganizationNotifier =
+        ref.read(githubOrganizationProvider.notifier);
 
     final qryResult = useQuery$getOrganizationList(
         Options$Query$getOrganizationList(
@@ -186,7 +201,8 @@ class Navigate2UserInfoView extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final qryResult = useQuery$getViewerID(Options$Query$getViewerID(fetchPolicy: FetchPolicy.networkOnly));
+    final qryResult = useQuery$getViewerID(
+        Options$Query$getViewerID(fetchPolicy: FetchPolicy.networkOnly));
     //ロード完了していない場合
     if (qryResult.result.isLoading) {
       return const LoadingAnimationWithAppbar();

--- a/lib/ui/toppage_view.dart
+++ b/lib/ui/toppage_view.dart
@@ -2,11 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:repositoryviewer/ui/module/loading_animation.dart';
 import 'package:repositoryviewer/provider/bookmarked_git_repository_provider.dart';
 import 'package:repositoryviewer/provider/github_account_setting_provider.dart';
-import 'package:repositoryviewer/ui/settings_view.dart';
 import 'package:repositoryviewer/ui/bookmarked_git_repository_view.dart';
+import 'package:repositoryviewer/ui/module/loading_animation.dart';
+import 'package:repositoryviewer/ui/settings_view.dart';
 
 import 'org_repository_list_view.dart';
 
@@ -18,7 +18,8 @@ class TopPageView extends HookConsumerWidget {
     final pageState = useState(0);
     final ghTokenProvider = ref.watch(githubTokenProvider);
 
-    final bookmarkedGitRepositoryInitialized = useFuture(useMemoized(() => ref.watch(bookmarkedGitRepositoriesProvider.notifier).initialized));
+    final bookmarkedGitRepositoryInitialized = useFuture(useMemoized(() =>
+        ref.watch(bookmarkedGitRepositoriesProvider.notifier).initialized));
     if (!bookmarkedGitRepositoryInitialized.hasData) {
       return const MaterialApp(home: LoadingAnimationWithAppbar());
     }
@@ -45,6 +46,7 @@ class TopPageView extends HookConsumerWidget {
     return GraphQLProvider(
         client: client,
         child: MaterialApp(
+          theme: ThemeData(useMaterial3: true),
           home: Scaffold(
               body: screens[pageState.value],
               bottomNavigationBar: BottomNavigationBar(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -149,26 +149,10 @@ packages:
     dependency: transitive
     description:
       name: connectivity_plus
-      sha256: "3f8fe4e504c2d33696dac671a54909743bc6a902a9bb0902306f7a2aed7e528e"
+      sha256: "745ebcccb1ef73768386154428a55250bc8d44059c19fd27aecda2a6dc013a22"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.9"
-  connectivity_plus_linux:
-    dependency: transitive
-    description:
-      name: connectivity_plus_linux
-      sha256: "3caf859d001f10407b8e48134c761483e4495ae38094ffcca97193f6c271f5e2"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.1"
-  connectivity_plus_macos:
-    dependency: transitive
-    description:
-      name: connectivity_plus_macos
-      sha256: "488d2de1e47e1224ad486e501b20b088686ba1f4ee9c4420ecbc3b9824f0b920"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.6"
+    version: "3.0.2"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -177,22 +161,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.3"
-  connectivity_plus_web:
-    dependency: transitive
-    description:
-      name: connectivity_plus_web
-      sha256: "81332be1b4baf8898fed17bb4fdef27abb7c6fd990bf98c54fd978478adf2f1a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.5"
-  connectivity_plus_windows:
-    dependency: transitive
-    description:
-      name: connectivity_plus_windows
-      sha256: "535b0404b4d5605c4dd8453d67e5d6d2ea0dd36e3b477f50f31af51b0aeab9dd"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.2"
   convert:
     dependency: transitive
     description:
@@ -348,90 +316,90 @@ packages:
     dependency: transitive
     description:
       name: gql
-      sha256: "7b4398b687334b4bf396e1e90b242db3475955ec1f9f2dbccd55b8b1339128b6"
+      sha256: "998304fbb88a3956cfea10cd27a56f8e5d4b3bc110f03c952c18a9310774e8bb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.2-alpha+1659715356091"
+    version: "0.14.0"
   gql_code_builder:
     dependency: transitive
     description:
       name: gql_code_builder
-      sha256: "7b4ead16971a2cec8746aaa2c18a430063fa4b5a42af152ad4e9cc68205736ad"
+      sha256: "27fd7dee009cea2bc982cacc461f66cc03e08ebf71cf8b0c78028cf280107ce7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.2-alpha+1659715356193"
+    version: "0.6.0"
   gql_dedupe_link:
     dependency: transitive
     description:
       name: gql_dedupe_link
-      sha256: "5c9e8a9204040a8eda3a1d871bbdfadc14a9c8a91f3013e02ba31aeba7d83fca"
+      sha256: "89681048cf956348e865da872a40081499b8c087fc84dd4d4b9c134bd70d27b3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3+1"
   gql_error_link:
     dependency: transitive
     description:
       name: gql_error_link
-      sha256: "7cf06f36586bf095cd0669447746a31a16b8bcdee282d52ab8524c42e9342141"
+      sha256: e7bfdd2b6232f3e15861cd96c2ad6b7c9c94693843b3dea18295136a5fb5b534
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.2"
+    version: "0.2.3+1"
   gql_exec:
     dependency: transitive
     description:
       name: gql_exec
-      sha256: "021e03066d02353126480427e44f183e5312162873ddeb07ef6a6938ab33d050"
+      sha256: "0d1fdb2e4154efbfc1dcf3f35ec36d19c8428ff0d560eb4c45b354f8f871dc50"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.1-alpha+1659715356108"
+    version: "0.4.3"
   gql_http_link:
     dependency: transitive
     description:
       name: gql_http_link
-      sha256: "304e1686d95d8dad7e19800ff9233c1c67d05d28d7ac9e7a8d665f5a0a829491"
+      sha256: "89ef87b32947acf4189f564c095f1148b0ab9bb9996fe518716dbad66708b834"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.5"
   gql_link:
     dependency: transitive
     description:
       name: gql_link
-      sha256: "87bb87fb01f2db5e8e99bef3230192d940a0d7a0065df4ad87d88426c5d39ed0"
+      sha256: f7973279126bc922d465c4f4da6ed93d187085e597b3480f5e14e74d28fe14bd
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.2"
+    version: "0.5.1"
   gql_transform_link:
     dependency: transitive
     description:
       name: gql_transform_link
-      sha256: "232f3b893a01bdb5d871ac6a682919b82ea732c04312a2f47ee114c8599d5d5e"
+      sha256: b1735a9a92d25a92960002a8b40dfaede95ec1e5ed848906125d69efd878661f
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.2"
+    version: "0.2.2+1"
   graphql:
     dependency: "direct main"
     description:
       name: graphql
-      sha256: "7fa7da84ca86e83ad5fda9f410bd90077cc53f8d836b1c6ce9e1c98c502f4f15"
+      sha256: b061201579040e9548cec2bae17bbdea0ab30666cb4e7ba48b9675f14d982199
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.1"
+    version: "5.1.3"
   graphql_codegen:
     dependency: "direct dev"
     description:
       name: graphql_codegen
-      sha256: "75a4bbab8d14fac45ca01d6902a7b3164b19f99b0281ac5352e4f85592faf1c5"
+      sha256: d8b5b70f3d0c6db6eec6e610185604a128fb275943543036cbce3f606d49cd77
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.2"
+    version: "0.12.0-beta.7"
   graphql_flutter:
     dependency: "direct main"
     description:
       name: graphql_flutter
-      sha256: "9ff835973d9b0e23194153944ecc7d12953d30ffe3ed23431bf476e2b0386ca4"
+      sha256: "06059ac9e8417c71582f05e28a59b1416d43959d34a6a0d9565341e3a362e117"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.0"
+    version: "5.1.2"
   graphs:
     dependency: transitive
     description:
@@ -588,10 +556,10 @@ packages:
     dependency: transitive
     description:
       name: normalize
-      sha256: "7d9b3cf6cc2366a858ca0b75c9f1a99d9dd69ac5aa7dbda01f0cf800a26687b2"
+      sha256: baf8caf2d8b745af5737cca6c24f7fe3cf3158897fdbcde9a909b9c8d3e2e5af
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0+1"
+    version: "0.7.2"
   package_config:
     dependency: transitive
     description:
@@ -600,6 +568,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: f619162573096d428ccde2e33f92e05b5a179cd6f0e3120c1005f181bee8ed16
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "9bc8ba46813a4cc42c66ab781470711781940780fd8beddd0c3da62506d3a6c6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   path:
     dependency: transitive
     description:
@@ -1009,10 +993,10 @@ packages:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: ca49c0bc209c687b887f30527fb6a9d80040b072cc2990f34b9bec3e7663101b
+      sha256: "3a969ddcc204a3e34e863d204b29c0752716f78b6f9cc8235083208d268a4ccd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.2.0"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   graphql: ^5.1.1
-  graphql_flutter: ^5.1.0
+  graphql_flutter: ^5.1.2
   url_launcher: ^6.1.6
   flutter_hooks: ^0.18.5+1
   hooks_riverpod: ^2.1.1
@@ -50,6 +50,7 @@ dependencies:
   json_annotation: ^4.7.0
   collection: ^1.16.0
   fluttertoast: ^8.1.2
+  package_info_plus: ^3.0.2
 
 dev_dependencies:
   flutter_test:
@@ -61,7 +62,7 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^2.0.0
-  graphql_codegen: ^0.11.2
+  graphql_codegen: ^0.12.0-beta.7
   build_runner: ^2.2.0
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+21
+version: 1.0.0+22
 
 environment:
   sdk: '>=2.18.4 <3.0.0'


### PR DESCRIPTION
変更点
* build errorになっていたのを修正 
  * `graphql_flutter`を5.11.2にupdate
  * `graphql_codegen`を0.12.0-beta.7にupdate
* Material3を有効にした
* Licenseのページを表示
* Githubのtoken入力画面を半角英数字記号のみ受け付けるよう変更
* FutureBuilderをuseMemorize, useFutureに変更